### PR TITLE
Compare bcrypt password for user login

### DIFF
--- a/Back/src/controller/UserCtrl.js
+++ b/Back/src/controller/UserCtrl.js
@@ -272,30 +272,35 @@ const EXPIRES_IN = process.env.JWT_EXPIRES;
 
 
 //add jwt token by users
-exports.loginuser = (req, res) => {
+exports.loginuser = async (req, res) => {
   const { Email, password } = req.body;
-  UserModel.loginUserprofile(Email, password)
-    .then((users) => {
-      if (users.length > 0) {
-        const jwt = require("jsonwebtoken");
-        const token = jwt.sign(
-          { id: users[0].id, role: users[0].role },
-          process.env.JWT_SECRET,
-          { expiresIn: process.env.JWT_EXPIRES || "1h"}
-        );
+  try {
+    const users = await UserModel.loginUserprofile(Email);
+    if (users.length === 0) {
+      return res.status(401).json({ message: "Invalid user email or password" });
+    }
 
-        res.status(200).json({
-          message: "login success",
-          user: users[0],
-          token: token, // 👈 send token also
-        });
-      } else {
-        res.status(401).json({ message: "Invalid user email or password" });
-      }
-    })
-    .catch((err) => {
-      res.status(500).json({ error: err.message });
+    const user = users[0];
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(401).json({ message: "Invalid user email or password" });
+    }
+
+    const token = jwt.sign(
+      { id: user.id, role: user.role },
+      process.env.JWT_SECRET || "mysecretkey",
+      { expiresIn: process.env.JWT_EXPIRES || "1h" }
+    );
+
+    const { password: _password, ...safeUser } = user;
+    return res.status(200).json({
+      message: "login success",
+      user: safeUser,
+      token
     });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
 };
 
 


### PR DESCRIPTION
Implement bcrypt password comparison for user login and return 401 on invalid credentials.

The previous login logic did not correctly compare bcrypt hashed passwords, allowing incorrect passwords to authenticate. This change explicitly uses `bcrypt.compare` to validate credentials and ensures the password field is excluded from the response.

---
<a href="https://cursor.com/background-agent?bcId=bc-86ac7b8b-6dc9-4e86-95ad-1013a711131d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86ac7b8b-6dc9-4e86-95ad-1013a711131d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

